### PR TITLE
Fixing card number issue

### DIFF
--- a/zklibtcp.js
+++ b/zklibtcp.js
@@ -631,7 +631,7 @@ class ZKLibTCP {
     command_string.writeUInt16LE(role, 2);
     command_string.write(password, 3, 8);
     command_string.write(name, 11, 24);
-    command_string.writeUInt16LE(cardno, 35);
+    command_string.writeUInt32LE(cardno, 35);
     command_string.writeUInt32LE(0, 40);
     command_string.write(userid ? userid.toString(9) : '', 48);
 


### PR DESCRIPTION
I noticed a issue that max value accepted into card number was '65535'. Even though, maximum length of card number is 10, I couldn't add 10 digits. I changed the writeUInt16() method to writeUInt32() which will support 10 digits, now. I didn't find it breaking the script. 
Thanks.